### PR TITLE
refactor: modernize type hints and update project dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ Pipfile.lock
 *.zip
 *.tar.gz
 *.7z
+uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+venv/
+ENV/
+env/
+
+# Jupyter Notebook
+.ipynb_checkpoints/
+*.nbconvert.ipynb
+
+# PyCharm
+.idea/
+
+# VSCode
+.vscode/
+
+# macOS
+.DS_Store
+
+# Linux
+*~
+
+# Logs
+logs/
+*.log
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.mypy_cache/
+.ruff_cache/
+
+# Type checking
+.pyre/
+
+# Data files
+data/
+datasets/
+*.csv
+*.tsv
+*.parquet
+*.feather
+*.h5
+*.hdf5
+*.db
+
+# Model artifacts
+models/
+checkpoints/
+*.ckpt
+*.pt
+*.pth
+*.onnx
+*.joblib
+*.pkl
+
+# Experiment tracking
+mlruns/
+wandb/
+tensorboard/
+runs/
+
+# Outputs
+outputs/
+results/
+figures/
+plots/
+reports/
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+
+# Secrets / credentials
+.env.local
+.env.*
+!.env.example
+
+# Package managers
+Pipfile.lock
+
+# Hatch
+.hatch/
+
+# DVC
+.dvc/cache/
+.dvc/tmp/
+
+# Snakemake
+.snakemake/
+
+# R
+.Rhistory
+.RData
+.Rproj.user/
+
+# Docker
+*.pid
+
+# AWS / cloud
+.aws/
+
+# IDE-specific notebooks
+.spyproject/
+
+# Ignore large binaries
+*.zip
+*.tar.gz
+*.7z

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
     given-names: Igor V.
 title: "KEGGaNOG"
 date-released: 2024-04-26
-url: https://github.com/iliapopov17/KEGGaNOG
+url: https://github.com/ilypopv/KEGGaNOG
 preferred-citation:
   type: article
   authors:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KEGGaNOG
 
-<img src="https://github.com/iliapopov17/KEGGaNOG/blob/main/imgs/KaN_logo_light.png#gh-light-mode-only" align="left" width = 25%/>
-<img src="https://github.com/iliapopov17/KEGGaNOG/blob/main/imgs/KaN_logo_dark.png#gh-dark-mode-only" align="left" width = 25%/>
+<img src="https://github.com/ilypopv/KEGGaNOG/blob/main/imgs/KaN_logo_light.png#gh-light-mode-only" align="left" width = 25%/>
+<img src="https://github.com/ilypopv/KEGGaNOG/blob/main/imgs/KaN_logo_dark.png#gh-dark-mode-only" align="left" width = 25%/>
 
 <br>
 <br>
@@ -10,7 +10,7 @@
 ![KEGG-Decoder](https://img.shields.io/badge/Dependecy-KEGG_Decoder-steelblue)
 ![License](https://img.shields.io/badge/License-MIT-steelblue)
 [![Downloads](https://static.pepy.tech/badge/kegganog)](https://pepy.tech/project/kegganog)
-[![codecov](https://codecov.io/gh/iliapopov17/KEGGaNOG/graph/badge.svg)](https://codecov.io/gh/iliapopov17/KEGGaNOG)
+[![codecov](https://codecov.io/gh/ilypopv/KEGGaNOG/graph/badge.svg)](https://codecov.io/gh/ilypopv/KEGGaNOG)
 
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
 ![macOS](https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=macos&logoColor=F0F0F0)
@@ -72,7 +72,7 @@ Usage: KEGGaNOG [OPTIONS]
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-🔗 Please visit [KEGGaNOG wiki](https://github.com/iliapopov17/KEGGaNOG/wiki) page
+🔗 Please visit [KEGGaNOG wiki](https://github.com/ilypopv/KEGGaNOG/wiki) page
 
 ### Web interface mode
 
@@ -104,11 +104,11 @@ These figures are generated using functional groupping mode (`-g`/`--group`) and
 
 ### User APIs visualization
 
-|[Barplot](https://github.com/iliapopov17/KEGGaNOG/wiki/Barplot-API)|[Boxplot](https://github.com/iliapopov17/KEGGaNOG/wiki/Boxplot-API)|[Radarplot](https://github.com/iliapopov17/KEGGaNOG/wiki/Radarplot-API)|[Correlation Network](https://github.com/iliapopov17/KEGGaNOG/wiki/Correlation-Network-API)|
+|[Barplot](https://github.com/ilypopv/KEGGaNOG/wiki/Barplot-API)|[Boxplot](https://github.com/ilypopv/KEGGaNOG/wiki/Boxplot-API)|[Radarplot](https://github.com/ilypopv/KEGGaNOG/wiki/Radarplot-API)|[Correlation Network](https://github.com/ilypopv/KEGGaNOG/wiki/Correlation-Network-API)|
 |-------|-------|---------|-------------------|
 |![image](https://github.com/user-attachments/assets/81d69bef-f69c-4960-b2d3-73e348e3853a)|![image](https://github.com/user-attachments/assets/f98fd993-20b7-4b00-b203-83b40fe35f9c)|![image](https://github.com/user-attachments/assets/dd75e5d8-e3c8-4eaa-b009-02c042534a53)|![image](https://github.com/user-attachments/assets/e76057b9-bcfd-4ba9-a4cf-cb7b4269441a)|
 
-|[Stacked Barplot](https://github.com/iliapopov17/KEGGaNOG/wiki/Stacked-Barplot-API)|[Streamgraph](https://github.com/iliapopov17/KEGGaNOG/wiki/Streamgraph-API)|[Stacked Barplot + Streamgraph](https://github.com/iliapopov17/KEGGaNOG/wiki/Combined-Stacked-Barplot-&-Streamgraph)|
+|[Stacked Barplot](https://github.com/ilypopv/KEGGaNOG/wiki/Stacked-Barplot-API)|[Streamgraph](https://github.com/ilypopv/KEGGaNOG/wiki/Streamgraph-API)|[Stacked Barplot + Streamgraph](https://github.com/ilypopv/KEGGaNOG/wiki/Combined-Stacked-Barplot-&-Streamgraph)|
 |-------|-------|-------|
 |![kgnstbar_OLD](https://github.com/user-attachments/assets/11e9e265-52c7-41b7-a284-64f3181caac3)|![kgnstream_OLD](https://github.com/user-attachments/assets/e82654fc-478a-4233-8478-f2c69ee4a1a6)|![combined_white_OLD](https://github.com/user-attachments/assets/6059da3c-4b74-47a2-af1c-427180f44845)|
 

--- a/kegganog/__init__.py
+++ b/kegganog/__init__.py
@@ -7,11 +7,11 @@ from .kgnplot.stackedbar import stacked_barplot
 from .kgnplot.streamgraph import streamgraph
 
 __all__: list[str] = [
+    "barplot",
     "boxplot",
     "correlation_network",
-    "barplot",
-    "radarplot",
     "heatmap",
-    "streamgraph",
+    "radarplot",
     "stacked_barplot",
+    "streamgraph",
 ]

--- a/kegganog/app.py
+++ b/kegganog/app.py
@@ -18,7 +18,7 @@ import tempfile
 import uuid
 from importlib.metadata import version as _metadata_version
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
 import pandas as pd
 from fastapi import FastAPI, Form, UploadFile
@@ -137,7 +137,7 @@ async def index() -> HTMLResponse:
 async def run_analysis(
     file: UploadFile,
     dpi: int = Form(default=300),
-    color: ValidColor = Form(default="Blues"),
+    color: Annotated[ValidColor, Form()] = "Blues",
     sample_name: str = Form(default="SAMPLE"),
     group: bool = Form(default=False),
 ) -> JobStatus | JSONResponse:
@@ -176,7 +176,7 @@ async def run_analysis(
 async def run_analysis_multi(
     files: list[UploadFile],
     dpi: int = Form(default=300),
-    color: ValidColor = Form(default="Blues"),
+    color: Annotated[ValidColor, Form()] = "Blues",
     group: bool = Form(default=False),
 ) -> JobStatus | JSONResponse:
     """Process an uploaded matrix collection array under cumulative memory safeguards."""
@@ -348,36 +348,36 @@ async def run_viz(
     title: str = Form(default=""),
     title_fontsize: float = Form(default=16.0),
     title_color: str = Form(default="black"),
-    title_weight: FontWeight = Form(default="normal"),
-    title_style: FontStyle = Form(default="normal"),
+    title_weight: Annotated[FontWeight, Form()] = "normal",
+    title_style: Annotated[FontStyle, Form()] = "normal",
     background_color: str = Form(default="white"),
     xlabel: str = Form(default=""),
     xlabel_fontsize: float = Form(default=14.0),
     xlabel_color: str = Form(default="black"),
-    xlabel_weight: FontWeight = Form(default="normal"),
-    xlabel_style: FontStyle = Form(default="normal"),
+    xlabel_weight: Annotated[FontWeight, Form()] = "normal",
+    xlabel_style: Annotated[FontStyle, Form()] = "normal",
     ylabel: str = Form(default=""),
     ylabel_fontsize: float = Form(default=14.0),
     ylabel_color: str = Form(default="black"),
-    ylabel_weight: FontWeight = Form(default="normal"),
-    ylabel_style: FontStyle = Form(default="normal"),
+    ylabel_weight: Annotated[FontWeight, Form()] = "normal",
+    ylabel_style: Annotated[FontStyle, Form()] = "normal",
     xticks_fontsize: float = Form(default=12.0),
     xticks_color: str = Form(default="black"),
-    xticks_weight: FontWeight = Form(default="normal"),
-    xticks_style: FontStyle = Form(default="normal"),
+    xticks_weight: Annotated[FontWeight, Form()] = "normal",
+    xticks_style: Annotated[FontStyle, Form()] = "normal",
     xticks_rotation: float = Form(default=0.0),
-    xticks_ha: HorizontalAlignment = Form(default="center"),
+    xticks_ha: Annotated[HorizontalAlignment, Form()] = "center",
     yticks_fontsize: float = Form(default=12.0),
     yticks_color: str = Form(default="black"),
-    yticks_weight: FontWeight = Form(default="normal"),
-    yticks_style: FontStyle = Form(default="normal"),
+    yticks_weight: Annotated[FontWeight, Form()] = "normal",
+    yticks_style: Annotated[FontStyle, Form()] = "normal",
     grid: bool = Form(default=True),
     grid_linestyle: str = Form(default="--"),
     grid_alpha: float = Form(default=0.7),
     cmap: str = Form(default=""),
     cmap_range_min: int = Form(default=8),
     cmap_range_max: int = Form(default=30),
-    sort_order: SortOrder = Form(default="descending"),
+    sort_order: Annotated[SortOrder, Form()] = "descending",
     box_color: str = Form(default="blue"),
     showfliers: bool = Form(default=True),
     grid_color: str = Form(default="gray"),
@@ -389,7 +389,7 @@ async def run_viz(
     node_linewidths: float = Form(default=1.5),
     label_fontsize: float = Form(default=8.0),
     label_color: str = Form(default="#03045E"),
-    label_weight: FontWeight = Form(default="normal"),
+    label_weight: Annotated[FontWeight, Form()] = "normal",
     edge_cmap: str = Form(default="coolwarm"),
     cbar_size: float = Form(default=0.5),
     pathways_selected: str = Form(default=""),
@@ -397,7 +397,7 @@ async def run_viz(
     sample_order: str = Form(default=""),
     fill_alpha: float = Form(default=0.25),
     line_width: float = Form(default=2.0),
-    line_style: LineStyle = Form(default="solid"),
+    line_style: Annotated[LineStyle, Form()] = "solid",
     label_background: str = Form(default=""),
     label_edgecolor: str = Form(default=""),
     label_pad: float = Form(default=1.05),
@@ -447,7 +447,7 @@ async def run_viz(
             return []
         try:
             return json.loads(s_clean)
-        except Exception:
+        except (json.JSONDecodeError, TypeError):
             return []
 
     figsize = (
@@ -532,7 +532,7 @@ async def run_viz(
             legend_fontsize,
             (legend_bbox_x, legend_bbox_y),
         )
-    except Exception as e:
+    except (ValueError, KeyError, FileNotFoundError, RuntimeError, TypeError) as e:
         return JSONResponse(status_code=500, content={"detail": str(e)})
 
     return FileResponse(path=png_path, media_type="image/png")
@@ -567,7 +567,13 @@ async def _run_job(job_id: str, file_bytes: bytes, params: WebParams) -> None:
                 "pathways": result.pathways,
             }
         )
-    except Exception as e:
+    except (
+        OSError,
+        ValueError,
+        RuntimeError,
+        pd.errors.EmptyDataError,
+        pd.errors.ParserError,
+    ) as e:
         _jobs[job_id].update({"status": "error", "message": str(e)})
 
 
@@ -596,7 +602,13 @@ async def _run_job_multi(
                 "pathways": result.pathways,
             }
         )
-    except Exception as e:
+    except (
+        OSError,
+        ValueError,
+        RuntimeError,
+        pd.errors.EmptyDataError,
+        pd.errors.ParserError,
+    ) as e:
         _jobs[job_id].update({"status": "error", "message": str(e)})
 
 

--- a/kegganog/app.py
+++ b/kegganog/app.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """FastAPI web application orchestration gateway for KEGGaNOG pipelines.
 
 This module exposes asynchronous endpoints for single- and multi-sample functional
@@ -19,7 +18,7 @@ import tempfile
 import uuid
 from importlib.metadata import version as _metadata_version
 from pathlib import Path
-from typing import Dict, FrozenSet, List, Literal, Optional, Tuple, Union
+from typing import Literal
 
 import pandas as pd
 from fastapi import FastAPI, Form, UploadFile
@@ -59,7 +58,7 @@ app.mount("/static", StaticFiles(directory=_static_dir), name="static")
 # ---------------------------------------------------------------------------
 
 # Explicit typing for central tracking registry mapping job UUIDs to properties
-_jobs: Dict[str, Dict[str, Union[str, Optional[Path], List[str]]]] = {}
+_jobs: dict[str, dict[str, str | Path | None | list[str]]] = {}
 
 # Upload constraints and boundary allocations
 MAX_UPLOAD_BYTES_SINGLE: int = 80 * 1024 * 1024
@@ -67,7 +66,7 @@ MAX_UPLOAD_BYTES_PER_MULTI_FILE: int = 80 * 1024 * 1024
 MAX_MULTI_UPLOAD_FILES: int = 64
 MAX_MULTI_BATCH_BYTES: int = 400 * 1024 * 1024
 
-_ALLOWED_PLOT_TYPES: FrozenSet[str] = frozenset(
+_ALLOWED_PLOT_TYPES: frozenset[str] = frozenset(
     {"barplot", "corrnet", "radarplot", "stackedbar", "streamgraph", "heatmap"}
 )
 
@@ -79,7 +78,7 @@ def _secure_temp_path(suffix: str) -> Path:
     return Path(path)
 
 
-def _safe_client_filename(filename: Optional[str]) -> str:
+def _safe_client_filename(filename: str | None) -> str:
     """Sanitize path-traversal anomalies out of multi-part uploaded file streams."""
     raw = (filename or "").strip() or "sample.annotations"
     base = Path(raw).name
@@ -90,7 +89,7 @@ def _safe_client_filename(filename: Optional[str]) -> str:
 
 async def _read_upload_with_limit(upload: UploadFile, max_bytes: int) -> bytes:
     """Read binary chunks sequentially while throwing exceptions if bounds are exceeded."""
-    chunks: List[bytes] = []
+    chunks: list[bytes] = []
     total = 0
     chunk_size = 1024 * 1024
     while True:
@@ -106,7 +105,7 @@ async def _read_upload_with_limit(upload: UploadFile, max_bytes: int) -> bytes:
     return b"".join(chunks)
 
 
-def _normalize_job_id(job_id: str) -> Optional[str]:
+def _normalize_job_id(job_id: str) -> str | None:
     """Validate input character strings against canonical UUID standards."""
     try:
         return str(uuid.UUID(job_id))
@@ -141,7 +140,7 @@ async def run_analysis(
     color: ValidColor = Form(default="Blues"),
     sample_name: str = Form(default="SAMPLE"),
     group: bool = Form(default=False),
-) -> Union[JobStatus, JSONResponse]:
+) -> JobStatus | JSONResponse:
     """Validate incoming single file parameters and schedule long-running threads."""
     try:
         params = WebParams(dpi=dpi, color=color, sample_name=sample_name, group=group)
@@ -175,11 +174,11 @@ async def run_analysis(
 
 @app.post("/run-multi", response_model=JobStatus)
 async def run_analysis_multi(
-    files: List[UploadFile],
+    files: list[UploadFile],
     dpi: int = Form(default=300),
     color: ValidColor = Form(default="Blues"),
     group: bool = Form(default=False),
-) -> Union[JobStatus, JSONResponse]:
+) -> JobStatus | JSONResponse:
     """Process an uploaded matrix collection array under cumulative memory safeguards."""
     valid_files = [f for f in files if f.filename and f.filename.strip()]
     if not valid_files:
@@ -198,7 +197,7 @@ async def run_analysis_multi(
         messages = [f"{err['loc'][0]}: {err['msg']}" for err in e.errors()]
         return JSONResponse(status_code=422, content={"detail": messages})
 
-    named_files: List[Tuple[str, bytes]] = []
+    named_files: list[tuple[str, bytes]] = []
     batch_total = 0
     for f in valid_files:
         try:
@@ -573,7 +572,7 @@ async def _run_job(job_id: str, file_bytes: bytes, params: WebParams) -> None:
 
 
 async def _run_job_multi(
-    job_id: str, named_files: List[Tuple[str, bytes]], params: WebParams
+    job_id: str, named_files: list[tuple[str, bytes]], params: WebParams
 ) -> None:
     """Execute collection serialization loops mapping structural tabular datasets."""
     _jobs[job_id]["status"] = "running"
@@ -609,7 +608,7 @@ async def _run_job_multi(
 def _blocking_viz(
     tsv_path: str,
     plot_type: str,
-    figsize: Optional[Tuple[float, float]],
+    figsize: tuple[float, float] | None,
     dpi: int,
     heatmap_color: str,
     heatmap_group: bool,
@@ -662,14 +661,14 @@ def _blocking_viz(
     label_weight: FontWeight,
     edge_cmap_name: str,
     cbar_size: float,
-    pathways_selected: List[str],
-    colors_selected: List[str],
-    sample_order: List[str],
+    pathways_selected: list[str],
+    colors_selected: list[str],
+    sample_order: list[str],
     fill_alpha: float,
     line_width: float,
     line_style: LineStyle,
-    label_background: Optional[str],
-    label_edgecolor: Optional[str],
+    label_background: str | None,
+    label_edgecolor: str | None,
     label_pad: float,
     show_legend: bool,
     legend_loc: str,
@@ -678,7 +677,7 @@ def _blocking_viz(
     edge_linewidth: float,
     stream_fill_alpha: float,
     legend_fontsize: float,
-    legend_bbox: Tuple[float, float],
+    legend_bbox: tuple[float, float],
 ) -> str:
     """Thread-isolated blocking core drawing dispatcher rendering static PNGs to temporary storage."""
     import matplotlib.pyplot as plt

--- a/kegganog/cheatmaps/grouped_heatmap.py
+++ b/kegganog/cheatmaps/grouped_heatmap.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Single-sample grouped three-panel heatmap generator module for KEGGaNOG.
 
 This module categorizes metabolic pathways into distinct biological buckets,
@@ -7,7 +6,7 @@ functional group metadata tags.
 """
 
 import warnings
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from collections.abc import Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -23,7 +22,7 @@ from .heatmaps_common import (
     save_heatmap_png,
 )
 
-function_groups: Dict[str, List[str]] = {
+function_groups: dict[str, list[str]] = {
     "Carbon fixation": [
         "3-Hydroxypropionate Bicycle",
         "4-Hydroxybutyrate/3-hydroxypropionate",
@@ -241,10 +240,10 @@ def generate_grouped_heatmap(
     output_folder: str,
     dpi: int,
     color: str,
-    sample_name: Optional[str],
-    figsize: Optional[Tuple[float, float]] = None,
+    sample_name: str | None,
+    figsize: tuple[float, float] | None = None,
     annot: bool = True,
-) -> Tuple[plt.Figure, Sequence[plt.Axes]]:
+) -> tuple[plt.Figure, Sequence[plt.Axes]]:
     """Generate a functional grouped three-panel heatmap for a single sample profile.
 
     Parses tabular data streams, maps specific keys to categorical clusters, introduces
@@ -278,7 +277,7 @@ def generate_grouped_heatmap(
         pbar.update(1)
 
         # Lowercase mapping for robust group categorization matching
-        function_groups_lower: Dict[str, Set[str]] = {
+        function_groups_lower: dict[str, set[str]] = {
             group: {func.lower() for func in funcs}
             for group, funcs in function_groups.items()
         }
@@ -380,8 +379,8 @@ def generate_grouped_heatmap(
         group_labels: Sequence[str],
         ax: plt.Axes,
         cbar: bool,
-        cbar_axis: Optional[plt.Axes] = None,
-        cbar_kws: Optional[Dict[str, str]] = None,
+        cbar_axis: plt.Axes | None = None,
+        cbar_kws: dict[str, str] | None = None,
     ) -> None:
         value_columns = part_df.columns[1:-1]
         part_df[value_columns] = part_df[value_columns].fillna(0)

--- a/kegganog/cheatmaps/grouped_heatmap.py
+++ b/kegganog/cheatmaps/grouped_heatmap.py
@@ -369,9 +369,11 @@ def generate_grouped_heatmap(
                     ha="right",
                     va="center",
                     weight="bold",
-                    bbox=dict(
-                        boxstyle="round,pad=0.3", edgecolor="none", facecolor="white"
-                    ),
+                    bbox={
+                        "boxstyle": "round,pad=0.3",
+                        "edgecolor": "none",
+                        "facecolor": "white",
+                    },
                 )
 
     def plot_heatmap(

--- a/kegganog/cheatmaps/grouped_heatmap_multi.py
+++ b/kegganog/cheatmaps/grouped_heatmap_multi.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Multi-sample grouped three-panel heatmap generator module for KEGGaNOG.
 
 This module processes composite matrices tracking functional group buckets across multiple
@@ -6,7 +5,7 @@ samples, calculates custom geometric margin pads, and draws unified partitioned 
 """
 
 import warnings
-from typing import Dict, Optional, Sequence, Tuple
+from collections.abc import Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,8 +28,8 @@ def generate_grouped_heatmap_multi(
     output_folder: str,
     dpi: int,
     color: str,
-    figsize: Optional[Tuple[float, float]] = None,
-) -> Tuple[plt.Figure, Sequence[plt.Axes]]:
+    figsize: tuple[float, float] | None = None,
+) -> tuple[plt.Figure, Sequence[plt.Axes]]:
     """Generate a functional grouped dynamic wide three-panel heatmap for multiple samples.
 
     Processes multidimensional pathway matrices, dynamically evaluates category margins,
@@ -172,8 +171,8 @@ def generate_grouped_heatmap_multi(
         group_labels: Sequence[str],
         ax: plt.Axes,
         cbar: bool,
-        cbar_axis: Optional[plt.Axes] = None,
-        cbar_kws: Optional[Dict[str, str]] = None,
+        cbar_axis: plt.Axes | None = None,
+        cbar_kws: dict[str, str] | None = None,
     ) -> None:
         value_columns = part_df.columns[1:-1]
         part_df[value_columns] = part_df[value_columns].fillna(0)

--- a/kegganog/cheatmaps/grouped_heatmap_multi.py
+++ b/kegganog/cheatmaps/grouped_heatmap_multi.py
@@ -161,9 +161,11 @@ def generate_grouped_heatmap_multi(
                     ha="right",
                     va="center",
                     weight="bold",
-                    bbox=dict(
-                        boxstyle="round,pad=0.3", edgecolor="none", facecolor="white"
-                    ),
+                    bbox={
+                        "boxstyle": "round,pad=0.3",
+                        "edgecolor": "none",
+                        "facecolor": "white",
+                    },
                 )
 
     def plot_heatmap(

--- a/kegganog/cheatmaps/heatmaps_common.py
+++ b/kegganog/cheatmaps/heatmaps_common.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Shared helper utilities and structural constants for KEGGaNOG heatmap layouts.
 
 This module houses categorical functional group buckets and geometric partitioning
@@ -8,7 +7,7 @@ algorithms utilizing multi-panel subplots to visualize KEGG module profiles.
 from __future__ import annotations
 
 import os
-from typing import Sequence, Tuple
+from collections.abc import Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -97,7 +96,7 @@ def insert_split_rows_between_groups(
 
 
 def create_three_panel_heatmap_figure(
-    figsize: Tuple[float, float],
+    figsize: tuple[float, float],
 ) -> tuple[plt.Figure, Sequence[plt.Axes], plt.Axes]:
     """Initialize a multi-panel grid layout consisting of three aligned subplots and a colorbar.
 

--- a/kegganog/cheatmaps/simple_heatmap.py
+++ b/kegganog/cheatmaps/simple_heatmap.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Single-sample three-panel heatmap generator module for KEGGaNOG profiles.
 
 This module processes raw KEGG-Decoder output strings, normalizes single-vector
@@ -6,7 +5,7 @@ functional columns, and projects values onto a partitioned matrix grid layout.
 """
 
 import warnings
-from typing import Optional, Sequence, Tuple
+from collections.abc import Sequence
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -25,10 +24,10 @@ def generate_heatmap(
     output_folder: str,
     dpi: int,
     color: str,
-    sample_name: Optional[str],
-    figsize: Optional[Tuple[float, float]] = None,
+    sample_name: str | None,
+    figsize: tuple[float, float] | None = None,
     annot: bool = True,
-) -> Tuple[plt.Figure, Sequence[plt.Axes]]:
+) -> tuple[plt.Figure, Sequence[plt.Axes]]:
     """Generate a publication-grade partitioned three-panel heatmap for a single sample vector.
 
     Parses raw tabular streams, extracts targeted function column headers, maps

--- a/kegganog/cheatmaps/simple_heatmap_multi.py
+++ b/kegganog/cheatmaps/simple_heatmap_multi.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Multi-sample three-panel heatmap generator module for KEGGaNOG profiles.
 
 This module processes comprehensive matrix datasets across multiple sample columns,
@@ -7,7 +6,7 @@ dynamically computes proportional layout limits, and draws parallel subplots.
 
 import logging
 import warnings
-from typing import Optional, Sequence, Tuple
+from collections.abc import Sequence
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -28,8 +27,8 @@ def generate_heatmap_multi(
     output_folder: str,
     dpi: int,
     color: str,
-    figsize: Optional[Tuple[float, float]] = None,
-) -> Tuple[plt.Figure, Sequence[plt.Axes]]:
+    figsize: tuple[float, float] | None = None,
+) -> tuple[plt.Figure, Sequence[plt.Axes]]:
     """Generate a publication-grade dynamic wide three-panel heatmap for multiple samples.
 
     Processes pre-loaded multi-column functional matrices, computes scaled width ratios,

--- a/kegganog/kegganog.py
+++ b/kegganog/kegganog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Main command-line interface entry point for KEGGaNOG.
 
 This module orchestrates the entire KEGGaNOG suite, exposing a unified interface
@@ -11,7 +10,6 @@ import shutil
 import sys
 from importlib.metadata import version as _metadata_version
 from pathlib import Path
-from typing import Optional
 
 import typer
 from pydantic import ValidationError
@@ -69,8 +67,8 @@ def _version_callback(value: bool) -> None:
 
 
 def _validate_params(
-    input_path: Optional[str],
-    output_dir: Optional[str],
+    input_path: str | None,
+    output_dir: str | None,
     multi: bool,
     overwrite: bool,
     dpi: int,
@@ -172,13 +170,13 @@ def _run_pipeline(params: CLIParams) -> None:
     no_args_is_help=True,
 )
 def main(
-    input_path: Optional[str] = typer.Option(
+    input_path: str | None = typer.Option(
         None,
         "-i",
         "--input",
         help="Path to eggNOG-mapper annotation file.",
     ),
-    output_dir: Optional[str] = typer.Option(
+    output_dir: str | None = typer.Option(
         None,
         "-o",
         "--output",
@@ -225,7 +223,7 @@ def main(
         "--web",
         help="Launch the interactive local web user interface dashboard at http://localhost:8000.",
     ),
-    version: Optional[bool] = typer.Option(
+    version: bool | None = typer.Option(
         None,
         "-V",
         "--version",

--- a/kegganog/kegganog.py
+++ b/kegganog/kegganog.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 from importlib.metadata import version as _metadata_version
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from pydantic import ValidationError
@@ -200,12 +201,14 @@ def main(
         "--dpi",
         help="DPI resolution mapping index for the output image visualization.",
     ),
-    color: ValidColor = typer.Option(
-        "Blues",
-        "-c",
-        "--color",
-        help="Target seaborn color map palette matrix rule.",
-    ),
+    color: Annotated[
+        ValidColor,
+        typer.Option(
+            "-c",
+            "--color",
+            help="Target seaborn color map palette matrix rule.",
+        ),
+    ] = "Blues",
     sample_name: str = typer.Option(
         "SAMPLE",
         "-n",

--- a/kegganog/kegganog_multi.py
+++ b/kegganog/kegganog_multi.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Orchestration engine for multi-sample functional profile processing.
 
 This module coordinates multi-sample data ingestion from file lists or single

--- a/kegganog/kgnplot/barplot.py
+++ b/kegganog/kgnplot/barplot.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python3
 """Horizontal barplot visualization module for KEGG module completion profiles.
 
 This module builds standalone sorted horizontal bar charts tracking individual
 pathway completeness scores extracted from eggNOG-mapper functional annotations.
 """
 
-from typing import Literal, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Literal
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -29,10 +29,10 @@ class KgnBarplot(KgnPlotBase):
 
 def barplot(
     df: pd.DataFrame,
-    figsize: Tuple[float, float] = (8.0, 12.0),
-    cmap: Union[str, Sequence[str]] = "Greens",
-    cmap_range: Tuple[int, int] = (8, 30),
-    title: Optional[str] = None,
+    figsize: tuple[float, float] = (8.0, 12.0),
+    cmap: str | Sequence[str] = "Greens",
+    cmap_range: tuple[int, int] = (8, 30),
+    title: str | None = None,
     title_fontsize: float = 16.0,
     title_color: str = "black",
     title_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
@@ -58,7 +58,7 @@ def barplot(
     grid: bool = True,
     grid_linestyle: str = "--",
     grid_alpha: float = 0.7,
-    background_color: Optional[str] = "white",
+    background_color: str | None = "white",
     sort_order: Literal["ascending", "descending"] = "descending",
 ) -> KgnBarplot:
     """Generate a publication-grade customizable horizontal barplot for pathway completeness.

--- a/kegganog/kgnplot/base.py
+++ b/kegganog/kgnplot/base.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Base lifecycle management module for KEGGaNOG mathematical graphics.
 
 This module establishes the core architectural contract for handling matplotlib
@@ -7,7 +6,7 @@ by wrapping heavy graphical contexts into explicit transaction objects.
 """
 
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import matplotlib.pyplot as plt
 
@@ -36,10 +35,10 @@ class KgnPlotBase:
 
     def savefig(
         self,
-        path: Union[str, Path],
+        path: str | Path,
         dpi: int = 300,
         transparent: bool = False,
-        bbox_inches: Optional[Union[Literal["tight"], str]] = "tight",
+        bbox_inches: Literal["tight"] | str | None = "tight",
     ) -> None:
         """Save the enclosed figure to a file using cross-platform safe IO pathways.
 

--- a/kegganog/kgnplot/boxplot.py
+++ b/kegganog/kgnplot/boxplot.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python3
 """Boxplot visualization module for KEGG module completion profiles.
 
 This module builds standalone box-and-whisker plots tracking macro-distribution
 metrics and pathway completeness density alterations across independent samples.
 """
 
-from typing import Literal, Optional, Tuple
+from typing import Literal
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -29,10 +28,10 @@ class KgnBoxplot(KgnPlotBase):
 
 def boxplot(
     df: pd.DataFrame,
-    figsize: Tuple[float, float] = (12.0, 6.0),
-    color: Optional[str] = "blue",
+    figsize: tuple[float, float] = (12.0, 6.0),
+    color: str | None = "blue",
     showfliers: bool = True,
-    title: Optional[str] = None,
+    title: str | None = None,
     title_fontsize: float = 16.0,
     title_color: str = "black",
     title_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
@@ -61,7 +60,7 @@ def boxplot(
     grid_color: str = "gray",
     grid_linestyle: str = "--",
     grid_linewidth: float = 0.5,
-    background_color: Optional[str] = "white",
+    background_color: str | None = "white",
 ) -> KgnBoxplot:
     """Generate a publication-grade customizable boxplot for pathway completeness distributions.
 

--- a/kegganog/kgnplot/corrnet.py
+++ b/kegganog/kgnplot/corrnet.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Correlation network visualization module for KEGG module completion profiles.
 
 This module builds standalone topological graph networks tracking sample-to-sample
@@ -6,7 +5,7 @@ reconstruction consistency and mathematical correlation strengths extracted from
 eggNOG-mapper functional annotations.
 """
 
-from typing import Literal, Optional, Tuple, Union
+from typing import Literal
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -32,7 +31,7 @@ class KgnCorrnet(KgnPlotBase):
 
 def correlation_network(
     df: pd.DataFrame,
-    figsize: Tuple[float, float] = (12.0, 6.0),
+    figsize: tuple[float, float] = (12.0, 6.0),
     threshold: float = 0.5,
     node_size: float = 700.0,
     node_color: str = "#A3D5FF",
@@ -43,15 +42,15 @@ def correlation_network(
     label_verticalalignment: Literal["center", "top", "bottom", "baseline"] = "center",
     label_horizontalalignment: Literal["center", "right", "left"] = "center",
     label_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
-    edge_cmap: Union[str, Colormap] = colormaps["coolwarm"],
+    edge_cmap: str | Colormap = colormaps["coolwarm"],
     cbar_size: float = 0.5,
-    title: Optional[str] = None,
+    title: str | None = None,
     title_fontsize: float = 16.0,
     title_color: str = "black",
     title_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
     title_style: Literal["normal", "italic", "oblique"] = "normal",
-    background_color: Optional[str] = "white",
-    save_matrix: Optional[str] = None,
+    background_color: str | None = "white",
+    save_matrix: str | None = None,
 ) -> KgnCorrnet:
     """Generate a publication-grade customizable correlation network for KEGG reconstructions.
 

--- a/kegganog/kgnplot/heatmap.py
+++ b/kegganog/kgnplot/heatmap.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Universal heatmap orchestration module for KEGG module completion profiles.
 
 This module acts as a unified factory interface routing data profiles between
@@ -11,7 +10,8 @@ import io
 import shutil
 import tempfile
 import warnings
-from typing import Any, Generator, Optional, Sequence, Tuple
+from collections.abc import Generator, Sequence
+from typing import Any
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -35,14 +35,14 @@ def silent_plot_and_tqdm() -> Generator[None, None, None]:
     def silent_show(*args: Any, **kwargs: Any) -> None:
         pass
 
-    setattr(plt, "show", silent_show)
+    plt.show = silent_show
 
     class SilentTqdm(tqdm.tqdm):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             kwargs["disable"] = True
             super().__init__(*args, **kwargs)
 
-    setattr(tqdm, "tqdm", SilentTqdm)
+    tqdm.tqdm = SilentTqdm
 
     with (
         contextlib.redirect_stdout(io.StringIO()),
@@ -71,10 +71,10 @@ class KgnHeatmap(KgnPlotBase):
 
 def heatmap(
     df: pd.DataFrame,
-    figsize: Optional[Tuple[float, float]] = None,
-    color: Optional[str] = None,
+    figsize: tuple[float, float] | None = None,
+    color: str | None = None,
     group: bool = False,
-    sample_name: Optional[str] = None,
+    sample_name: str | None = None,
     annot: bool = True,
 ) -> KgnHeatmap:
     """Universal heatmap router factory for single and multi-sample KEGG reconstructions.

--- a/kegganog/kgnplot/radarplot.py
+++ b/kegganog/kgnplot/radarplot.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Radar plot visualization module for KEGG module completion profiles.
 
 This module builds standalone polar spider/radar charts tracking individual
@@ -6,7 +5,8 @@ pathway completeness metrics across continuous sample coordinates.
 """
 
 import warnings
-from typing import Literal, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -31,10 +31,10 @@ class KgnRadar(KgnPlotBase):
 def radarplot(
     df: pd.DataFrame,
     pathways: Sequence[str],
-    figsize: Tuple[float, float] = (8.0, 8.0),
-    colors: Optional[Sequence[str]] = None,
-    sample_order: Optional[Sequence[str]] = None,
-    title: Optional[str] = None,
+    figsize: tuple[float, float] = (8.0, 8.0),
+    colors: Sequence[str] | None = None,
+    sample_order: Sequence[str] | None = None,
+    title: str | None = None,
     title_fontsize: float = 14.0,
     title_color: str = "black",
     title_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
@@ -44,20 +44,20 @@ def radarplot(
     label_color: str = "black",
     label_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
     label_style: Literal["normal", "italic", "oblique"] = "normal",
-    label_background: Optional[str] = None,
-    label_edgecolor: Optional[str] = None,
+    label_background: str | None = None,
+    label_edgecolor: str | None = None,
     label_pad: float = 1.05,
     ytick_fontsize: float = 8.0,
     ytick_color: str = "black",
     ytick_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
     ytick_alpha: float = 0.5,
-    yticklabels: Optional[Sequence[str]] = None,
+    yticklabels: Sequence[str] | None = None,
     fill_alpha: float = 0.25,
     line_width: float = 2.0,
     line_style: Literal["solid", "dashed", "dashdot", "dotted", "-"] = "solid",
-    background_color: Optional[str] = "white",
+    background_color: str | None = "white",
     legend_loc: str = "upper right",
-    legend_bbox: Tuple[float, float] = (1.3, 1.1),
+    legend_bbox: tuple[float, float] = (1.3, 1.1),
     show_legend: bool = True,
 ) -> KgnRadar:
     """Generate a publication-grade customizable polar radar chart for KEGG pathways.

--- a/kegganog/kgnplot/radarplot.py
+++ b/kegganog/kgnplot/radarplot.py
@@ -109,7 +109,7 @@ def radarplot(
 
     # Initialize structural subplots container canvas layers
     fig, ax = plt.subplots(
-        figsize=figsize, subplot_kw=dict(polar=True), facecolor=background_color
+        figsize=figsize, subplot_kw={"polar": True}, facecolor=background_color
     )
 
     # Establish palette map dictionaries compliant with static analysis
@@ -171,11 +171,11 @@ def radarplot(
             fontweight=label_weight,
             style=label_style,
             bbox=(
-                dict(
-                    facecolor=label_background if label_background else "none",
-                    edgecolor=label_edgecolor if label_edgecolor else "none",
-                    boxstyle="round,pad=0.2",
-                )
+                {
+                    "facecolor": label_background if label_background else "none",
+                    "edgecolor": label_edgecolor if label_edgecolor else "none",
+                    "boxstyle": "round,pad=0.2",
+                }
                 if label_background or label_edgecolor
                 else None
             ),

--- a/kegganog/kgnplot/stackedbar.py
+++ b/kegganog/kgnplot/stackedbar.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Stacked barplot visualization module for KEGG module completion profiles.
 
 This module builds normalized, multi-component stacked column charts tracking
@@ -6,7 +5,8 @@ aggregated functional pathway group completeness variations derived from
 eggNOG-mapper orthology annotations across independent samples.
 """
 
-from typing import Literal, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -32,12 +32,12 @@ class KgnStackedBarplot(KgnPlotBase):
 
 def stacked_barplot(
     df: pd.DataFrame,
-    figsize: Tuple[float, float] = (14.0, 7.0),
-    cmap: Union[str, Sequence[str]] = "tab20",
+    figsize: tuple[float, float] = (14.0, 7.0),
+    cmap: str | Sequence[str] = "tab20",
     bar_width: float = 0.6,
     edgecolor: str = "black",
     edge_linewidth: float = 0.3,
-    title: Optional[str] = None,
+    title: str | None = None,
     title_fontsize: float = 16.0,
     title_color: str = "black",
     title_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
@@ -58,13 +58,13 @@ def stacked_barplot(
     xticks_color: str = "black",
     xticks_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
     xticks_style: Literal["normal", "italic", "oblique"] = "normal",
-    background_color: Optional[str] = "white",
+    background_color: str | None = "white",
     grid: bool = True,
     grid_linestyle: str = "--",
     grid_alpha: float = 0.7,
     legend_fontsize: float = 9.0,
     legend_loc: str = "upper left",
-    legend_bbox: Tuple[float, float] = (1.05, 1.0),
+    legend_bbox: tuple[float, float] = (1.05, 1.0),
     show_legend: bool = True,
 ) -> KgnStackedBarplot:
     """Generate a publication-grade customizable stacked barplot for KEGG pathway groups.

--- a/kegganog/kgnplot/streamgraph.py
+++ b/kegganog/kgnplot/streamgraph.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Streamgraph visualization module for KEGG module completion profiles.
 
 This module builds continuous, multi-component streamgraph layouts tracking
@@ -6,7 +5,8 @@ aggregated functional pathway group completeness variations derived from
 eggNOG-mapper orthology annotations across independent samples.
 """
 
-from typing import Literal, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -32,13 +32,13 @@ class KgnStreamgraph(KgnPlotBase):
 
 def streamgraph(
     df: pd.DataFrame,
-    figsize: Tuple[float, float] = (14.0, 7.0),
-    cmap: Union[str, Sequence[str]] = "tab20",
+    figsize: tuple[float, float] = (14.0, 7.0),
+    cmap: str | Sequence[str] = "tab20",
     bar_width: float = 0.6,
     fill_alpha: float = 1.0,
-    edgecolor: Optional[str] = None,
+    edgecolor: str | None = None,
     edge_linewidth: float = 0.3,
-    title: Optional[str] = None,
+    title: str | None = None,
     title_fontsize: float = 16.0,
     title_color: str = "black",
     title_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
@@ -59,13 +59,13 @@ def streamgraph(
     xticks_color: str = "black",
     xticks_weight: Literal["normal", "bold", "heavy", "light"] = "normal",
     xticks_style: Literal["normal", "italic", "oblique"] = "normal",
-    background_color: Optional[str] = "white",
+    background_color: str | None = "white",
     grid: bool = True,
     grid_linestyle: str = "--",
     grid_alpha: float = 0.7,
     legend_fontsize: float = 9.0,
     legend_loc: str = "upper left",
-    legend_bbox: Tuple[float, float] = (1.05, 1.0),
+    legend_bbox: tuple[float, float] = (1.05, 1.0),
     show_legend: bool = True,
 ) -> KgnStreamgraph:
     """Generate a publication-grade customizable streamgraph for KEGG pathway groups.

--- a/kegganog/processing/data_processing.py
+++ b/kegganog/processing/data_processing.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Data parsing and execution sub-engine for internal functional profile workflows.
 
 This module handles the extraction and formatting of KO (KEGG Orthology) terms

--- a/kegganog/processing/data_processing_multi.py
+++ b/kegganog/processing/data_processing_multi.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Data parsing, execution, and matrix aggregation engine for multi-cohort workflows.
 
 This module orchestrates parallel or sequential functional evaluation of multiple

--- a/kegganog/processing/pipeline.py
+++ b/kegganog/processing/pipeline.py
@@ -13,9 +13,9 @@ import os
 import shutil
 import tempfile
 import zipfile
+from collections.abc import Generator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Generator, Optional
 
 import pandas as pd
 
@@ -106,7 +106,7 @@ def _pack_results(output_dir: Path) -> tuple[Path, Path]:
 
 @contextlib.contextmanager
 def _resolve_output_context(
-    output_dir: Optional[Path | str],
+    output_dir: Path | str | None,
 ) -> Generator[Path, None, None]:
     """Yield a stable active target directory context matching CLI or Web runstates.
 
@@ -227,7 +227,7 @@ def run_single(
     dpi: int,
     color: ValidColor,
     group: bool,
-    output_dir: Optional[Path | str] = None,
+    output_dir: Path | str | None = None,
 ) -> PipelineResult:
     """Execute the full core functional annotation profile pathway pipeline.
 
@@ -265,7 +265,7 @@ def run_multi(
     dpi: int,
     color: ValidColor,
     group: bool,
-    output_dir: Optional[Path | str] = None,
+    output_dir: Path | str | None = None,
 ) -> PipelineResult:
     """Execute the aggregate multi-sample cohort analytical matrix workflow.
 

--- a/kegganog/schemas.py
+++ b/kegganog/schemas.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Pydantic schemas for data validation in KEGGaNOG.
 
 This module defines the structural contracts used across both the

--- a/kegganog/static/index.html
+++ b/kegganog/static/index.html
@@ -57,7 +57,7 @@
       Full-text paper
     </a>
 
-    <a class="nav-github" href="https://github.com/iliapopov17/KEGGaNOG" target="_blank">
+    <a class="nav-github" href="https://github.com/ilypopv/KEGGaNOG" target="_blank">
       <span class="nav-github-main">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577

--- a/kegganog/static/js/ui.js
+++ b/kegganog/static/js/ui.js
@@ -28,7 +28,7 @@ function hideStatus() {
 }
 
 // Live GitHub star count
-fetch("https://api.github.com/repos/iliapopov17/KEGGaNOG")
+fetch("https://api.github.com/repos/ilypopv/KEGGaNOG")
   .then(r => r.json())
   .then(d => {
     if (d.stargazers_count !== undefined)

--- a/kegganog/web.py
+++ b/kegganog/web.py
@@ -51,7 +51,7 @@ def launch() -> None:
         )
     except KeyboardInterrupt:
         print("\n  Server stopped by user. Goodbye!")
-    except Exception as e:
+    except (OSError, RuntimeError, ImportError, ModuleNotFoundError) as e:
         print(f"\n  Critical server error: {e}")
 
 

--- a/kegganog/web.py
+++ b/kegganog/web.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Entry point for the KEGGaNOG desktop web application.
 
 Orchestrates the lifecycle of the Uvicorn ASGI server and coordinates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
-    "httpx>=0.27.0",
+    "httpx2>=2.9.1",
     "pytest-asyncio>=0.23.0",
 ]
 
@@ -59,6 +59,7 @@ filterwarnings = [
     "ignore::UserWarning:seaborn",
     "ignore::PendingDeprecationWarning:seaborn",
 ]
+pythonpath = ["."]
 
 [tool.coverage.run]
 omit = ["*/processing/KEGG_decoder.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kegganog"
-version = "1.6.5"
+version = "1.6.6"
 description = "A tool for generating KEGG heatmaps from eggNOG-mapper outputs."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ test_heatmaps_characterization.py ← cheatmap rendering reproducibility (PNG ha
 test_kgnplot.py                ← kgnplot public API smoke + parameter-validation tests
 test_app_helpers.py            ← app.py pure helpers (_normalize_job_id, _safe_client_filename)
                                    and per-route unit tests that need _jobs manipulation
-test_web_routes.py             ← HTTP-level FastAPI surface tests (TestClient / httpx)
+test_web_routes.py             ← HTTP-level FastAPI surface tests (TestClient / httpx2)
 test_web_launch.py             ← kegganog.web launch + browser-open tests
 """
 

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -19,7 +19,7 @@ import uuid
 import zipfile
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 from fastapi.testclient import TestClient
 
@@ -278,8 +278,10 @@ async def test_viz_barplot_with_fixture_tsv(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(f"/viz/{job_id}", data={"plot_type": "barplot"})
         assert r.status_code == 200
         assert r.headers.get("content-type", "").startswith("image/png")
@@ -310,8 +312,10 @@ async def test_viz_corrnet_returns_png(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(f"/viz/{job_id}", data={"plot_type": "corrnet"})
         assert r.status_code == 200
         assert r.headers.get("content-type", "").startswith("image/png")
@@ -337,8 +341,10 @@ async def test_viz_corrnet_invalid_edge_cmap_falls_back_gracefully(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(
                 f"/viz/{job_id}",
                 data={"plot_type": "corrnet", "edge_cmap": "not a valid cmap name!"},
@@ -367,8 +373,10 @@ async def test_viz_radarplot_no_pathways_selected_returns_500(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(
                 f"/viz/{job_id}",
                 data={"plot_type": "radarplot", "pathways_selected": ""},
@@ -395,8 +403,10 @@ async def test_viz_stackedbar_returns_png(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(f"/viz/{job_id}", data={"plot_type": "stackedbar"})
         assert r.status_code == 200
         assert r.headers.get("content-type", "").startswith("image/png")
@@ -421,8 +431,10 @@ async def test_viz_streamgraph_returns_png(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(f"/viz/{job_id}", data={"plot_type": "streamgraph"})
         assert r.status_code == 200
         assert r.headers.get("content-type", "").startswith("image/png")
@@ -448,8 +460,10 @@ async def test_viz_heatmap_single_simple_returns_png(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(
                 f"/viz/{job_id}",
                 data={
@@ -482,8 +496,10 @@ async def test_viz_heatmap_single_grouped_returns_png(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(
                 f"/viz/{job_id}",
                 data={
@@ -516,8 +532,10 @@ async def test_viz_heatmap_multi_simple_returns_png(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(
                 f"/viz/{job_id}",
                 data={"plot_type": "heatmap", "heatmap_group": "false"},
@@ -546,8 +564,10 @@ async def test_viz_heatmap_multi_grouped_returns_png(tmp_path):
         "message": "",
     }
     try:
-        transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        transport = httpx2.ASGITransport(app=app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(
                 f"/viz/{job_id}",
                 data={"plot_type": "heatmap", "heatmap_group": "true"},

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -22,15 +22,7 @@ from kegganog.processing.data_processing import _ensure_kegg_decoder
 # Helpers
 # ---------------------------------------------------------------------------
 
-_EMAPPER_HEADER = "\n".join(
-    [
-        "## header line 1",
-        "## header line 2",
-        "## header line 3",
-        "## header line 4",
-        "KEGG_ko\tOther",
-    ]
-)
+_EMAPPER_HEADER = "## header line 1\n## header line 2\n## header line 3\n## header line 4\nKEGG_ko\tOther"
 
 
 def _write_emapper(path: Path, ko_entries: list[str]) -> None:
@@ -97,9 +89,11 @@ def test_ensure_kegg_decoder_downloads_when_missing(tmp_path):
 def test_ensure_kegg_decoder_raises_on_network_failure(tmp_path):
     script_path = tmp_path / "KEGG_decoder.py"
 
-    with patch("requests.get", side_effect=Exception("network error")):
-        with pytest.raises(RuntimeError, match="Failed to download"):
-            _ensure_kegg_decoder(script_path)
+    with (
+        patch("requests.get", side_effect=Exception("network error")),
+        pytest.raises(RuntimeError, match="Failed to download"),
+    ):
+        _ensure_kegg_decoder(script_path)
 
     assert not script_path.exists()
 

--- a/tests/test_data_processing_multi.py
+++ b/tests/test_data_processing_multi.py
@@ -21,15 +21,7 @@ from kegganog.processing import data_processing_multi
 # Helpers
 # ---------------------------------------------------------------------------
 
-_EMAPPER_HEADER = "\n".join(
-    [
-        "## header line 1",
-        "## header line 2",
-        "## header line 3",
-        "## header line 4",
-        "KEGG_ko\tOther",
-    ]
-)
+_EMAPPER_HEADER = "## header line 1\n## header line 2\n## header line 3\n## header line 4\nKEGG_ko\tOther"
 
 
 def _write_emapper(path: Path, ko_entries: list[str]) -> None:
@@ -38,7 +30,7 @@ def _write_emapper(path: Path, ko_entries: list[str]) -> None:
 
 def _write_pathways_tsv(path: Path, prefix: str, values: list[float]) -> None:
     """Write a minimal KEGG-Decoder-style pathways TSV for merge tests."""
-    headers = "\t".join(["Glycolysis", "TCA Cycle"])
+    headers = "Glycolysis\tTCA Cycle"
     vals = "\t".join(str(v) for v in values)
     path.write_text(f"{prefix}\t{headers}\n{prefix}\t{vals}\n")
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -36,7 +36,7 @@ from kegganog.processing.pipeline import (
 
 def _make_minimal_png_bytes() -> bytes:
     buf = io.BytesIO()
-    fig, ax = plt.subplots(figsize=(1, 1))
+    fig, _ax = plt.subplots(figsize=(1, 1))
     fig.savefig(buf, format="png", dpi=72)
     plt.close(fig)
     return buf.getvalue()

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -11,7 +11,7 @@ import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
-import httpx
+import httpx2
 import pytest
 from conftest import make_minimal_png
 from fastapi.testclient import TestClient
@@ -92,14 +92,16 @@ async def test_run_completes_with_mocked_pipeline(tmp_path: Path) -> None:
             pathways=fake["pathways"],
         )
 
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx2.ASGITransport(app=app)
     # The patch must wrap the *entire* flow — POST + polling + assertions —
     # because the background worker runs in a thread pool and may call
     # run_single after the POST coroutine has already returned.  Exiting the
     # patch context before the worker finishes causes the real run_single to
     # be called with b"dummy" bytes, which blows up on missing KEGG_ko column.
     with patch("kegganog.app.run_single", fake_run_single):
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
             r = await ac.post(
                 "/run",
                 files={"file": ("in.tsv", b"dummy", "text/tab-separated-values")},


### PR DESCRIPTION
## 📝 Summary
This PR modernizes the codebase by adopting Python 3.10+ type hinting syntax (PEP 585 and PEP 604) across all modules, replacing legacy `typing` generics with
built-in collections. It also updates project metadata to reflect new repository URLs and migrates the testing suite from `httpx` to `httpx2`.

## 🛠 Type of Change
-  Refactoring

## 🔍 Key Changes
- **Type Hint Modernization**: Replaced `List`, `Dict`, `Tuple`, `Union`, and `Optional` with modern alternatives like `list`, `dict`, `tuple`, and the `|` 
operator across the entire repository.
- **Dependency Update**: Migrated from `httpx` to `httxt2` in `pyproject.toml` and updated all corresponding test implementations.
- **Improved Error Handling**: Refined exception blocks in `app.py` and `web.py` to catch specific error types (e.g., `json.JSONDecodeError`, `OSError`) 
instead of broad `Exception` catches, improving debuggability.
- **FastAPI Refactoring**: Utilized `Annotated` for defining `Form` parameters in the web application to align with modern FastAPI best practices.
- **Metadata & URL Updates**: Updated GitHub repository URLs in `README.md`, `CITATION.cff`, and static HTML assets to reflect the updated user handle.
- **Project Maintenance**: Added a comprehensive `.gitignore` file covering Python, Jupyter, and ML-related artifacts (models, datasets, etc.).

## 🧪 How Has This Been Tested?
- Verified that the existing test suite passes using `pytest`.
- Confirmed that all integration tests in `tests/test_app_helpers.py` and `tests/test_web_routes.py` correctly utilize the new `httpx2` client.
- Validated that the web application launch sequence remains stable with the updated exception handling logic.